### PR TITLE
Optimize downloading apt key

### DIFF
--- a/docs/run.sh
+++ b/docs/run.sh
@@ -168,7 +168,7 @@ BootstrapLinux() {
     ## Check for gpg-agent and install if needed
     test -x /usr/bin/gpg-agent || sudo apt install -y --no-install-recommends gpg-agent
     ## Get the key if it is missing
-    if !test -f /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc; then
+    if ! test -f /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc; then
        wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
     fi
     ## Add the repo

--- a/docs/run.sh
+++ b/docs/run.sh
@@ -167,8 +167,10 @@ BootstrapLinux() {
     test -x /usr/bin/gpg || sudo apt install -y --no-install-recommends gnupg
     ## Check for gpg-agent and install if needed
     test -x /usr/bin/gpg-agent || sudo apt install -y --no-install-recommends gpg-agent
-    ## Get the key
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+    ## Get the key if it is missing
+    if !test -f /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc; then
+       wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+    fi
     ## Add the repo
     if [[ "${R_VERSION}" == "4.0" ]]; then
         ## need pinning to ensure repo sorts higher


### PR DESCRIPTION
Hi,

at times (e.g. today), downloading marutter's key for the CRAN apt repos from launchpad's key server is unreliable and times out. Additionally, apt-key complains about using the old /etc/apt/trusted.gpg keyring directly. This PR addresses both problems by:
* Changing to the `/etc/apt/trusted.gpg.d` format
* Downloading the key from cloud.r-project.org instead of launchpad's key servers
* Only downloading the key when it doesn't exist yet

I tested the change, and works beautifully, at least on ubuntu-latest on github.

Cheers,

Mika