### PR TITLE
guard macOS xcode-select against missing pinned Xcode

### DIFF
--- a/docs/dev_run.sh
+++ b/docs/dev_run.sh
@@ -41,6 +41,8 @@ MAKEFLAGS=${MAKEFLAGS:-"-j 4"}
 BOOTSTRAP_MACOS_FORTRAN=${BOOTSTRAP_MACOS_FORTRAN:-"TRUE"}
 ## Install OpenMP on macOS as well -- no longer by default
 BOOTSTRAP_MACOS_OPENMP=${BOOTSTRAP_MACOS_OPENMP:-"TRUE"}
+## Xcode selected after the macOS OpenMP install -- override for platforms needing a specific version
+BOOTSTRAP_MACOS_XCODE=${BOOTSTRAP_MACOS_XCODE:-"/Applications/Xcode.app"}
 
 R_BUILD_ARGS=${R_BUILD_ARGS-"--no-build-vignettes --no-manual"}
 R_CHECK_ARGS=${R_CHECK_ARGS-"--no-vignettes --no-manual --as-cran"}
@@ -311,7 +313,9 @@ BootstrapMacOptions() {
         echo "Installing macOS OpenMP binary package"
         sudo tar fvxz /tmp/$omptgz -C /
         rm /tmp/$omptgz
-        sudo xcode-select -s /Applications/Xcode_16.2.app
+        if [[ -n "$BOOTSTRAP_MACOS_XCODE" ]] && [[ -d "$BOOTSTRAP_MACOS_XCODE" ]]; then
+            sudo xcode-select -s "$BOOTSTRAP_MACOS_XCODE"
+        fi
         echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
         echo "  xcode is set: $(xcode-select --print-path)"
         echo "  using SDK: $(xcrun --show-sdk-version)"

--- a/docs/run.sh
+++ b/docs/run.sh
@@ -41,6 +41,8 @@ MAKEFLAGS=${MAKEFLAGS:-"-j 4"}
 BOOTSTRAP_MACOS_FORTRAN=${BOOTSTRAP_MACOS_FORTRAN:-"TRUE"}
 ## Install OpenMP on macOS as well -- no longer by default
 BOOTSTRAP_MACOS_OPENMP=${BOOTSTRAP_MACOS_OPENMP:-"TRUE"}
+## Xcode selected after the macOS OpenMP install -- override for platforms needing a specific version
+BOOTSTRAP_MACOS_XCODE=${BOOTSTRAP_MACOS_XCODE:-"/Applications/Xcode.app"}
 
 R_BUILD_ARGS=${R_BUILD_ARGS-"--no-build-vignettes --no-manual"}
 R_CHECK_ARGS=${R_CHECK_ARGS-"--no-vignettes --no-manual --as-cran"}
@@ -314,7 +316,9 @@ BootstrapMacOptions() {
         echo "Installing macOS OpenMP binary package"
         sudo tar fvxz /tmp/$omptgz -C /
         rm /tmp/$omptgz
-        sudo xcode-select -s /Applications/Xcode_16.2.app
+        if [[ -n "$BOOTSTRAP_MACOS_XCODE" ]] && [[ -d "$BOOTSTRAP_MACOS_XCODE" ]]; then
+            sudo xcode-select -s "$BOOTSTRAP_MACOS_XCODE"
+        fi
         echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
         echo "  xcode is set: $(xcode-select --print-path)"
         echo "  using SDK: $(xcrun --show-sdk-version)"


### PR DESCRIPTION
### Problem

The macOS OpenMP bootstrap in `docs/run.sh` (and `docs/dev_run.sh`) hardcodes:

```sh
sudo xcode-select -s /Applications/Xcode_16.2.app
```

Newer GitHub runner images no longer ship Xcode 16.2. On the current `macos-latest` (the `macos-26-arm64` image, which carries only Xcode 26.x) this fails with:

```
xcode-select: error: invalid developer directory '/Applications/Xcode_16.2.app'
```

and aborts the run during bootstrap. This is currently breaking macOS CI for downstream users (surfaced via Rcpp's reverse-dependency checks).

### Fix

- Default the selected toolchain to the image's `/Applications/Xcode.app` symlink, which is present on every macOS runner and points at the image's intended default Xcode -- effectively reaffirming the default rather than pinning a version that rotates out.
- Add a `BOOTSTRAP_MACOS_XCODE` environment override for platforms that genuinely need a specific Xcode (e.g. set it to `/Library/Developer/CommandLineTools` or a pinned `Xcode_XX.app`).
- Only call `xcode-select -s` when the target directory actually exists, so a missing path is a no-op instead of a hard failure.

`MACOSX_DEPLOYMENT_TARGET=11.0` is still exported, so the minimum deployment target is unchanged; only the SDK/toolchain follows the image default.

Applied identically to `docs/run.sh` and `docs/dev_run.sh`. Both pass `bash -n`.
